### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,27 +7,27 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-A20lib                  KEYWORD1
-callInfo               KEYWORD1
+A20lib	KEYWORD1
+callInfo	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin                  KEYWORD2
-powerCycle             KEYWORD2
+begin	KEYWORD2
+powerCycle	KEYWORD2
 
-dial                   KEYWORD2
-redial                 KEYWORD2
-hangUp                 KEYWORD2
-checkCallStatus        KEYWORD2
-getSignalStrength      KEYWORD2
+dial	KEYWORD2
+redial	KEYWORD2
+hangUp	KEYWORD2
+checkCallStatus	KEYWORD2
+getSignalStrength	KEYWORD2
 
-sendSMS                KEYWORD2
+sendSMS	KEYWORD2
 
-setVol                 KEYWORD2
+setVol	KEYWORD2
 
-A20conn                KEYWORD2
+A20conn	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords